### PR TITLE
Quit: wait for reply instead of closing the connection prematurely

### DIFF
--- a/pop3.go
+++ b/pop3.go
@@ -126,7 +126,7 @@ func (c *Client) Pass(p string) (err error) {
 
 // Quit sends the quit command to the server and closes the socket.
 func (c *Client) Quit() (err error) {
-	if err = c.Send("%s\r\n", QUIT); err != nil {
+	if _, err = c.Cmd("%s\r\n", QUIT); err != nil {
 		return
 	}
 	return c.conn.Close()


### PR DESCRIPTION
Servers only delete messages when they receive a QUIT command.

The QUIT command may take some time, and if servers close connections
as soon as the remote side closes them, the delete might be interrupted.