### PR TITLE
Return actual error message from the server instead of hardcoded one.

### DIFF
--- a/pop3.go
+++ b/pop3.go
@@ -5,7 +5,6 @@ package pop3
 import (
 	"bufio"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -45,8 +44,8 @@ func NewClient(conn net.Conn) (c *Client, err error) {
 	if err != nil {
 		return
 	}
-	if !IsOK(line) {
-		return nil, errors.New("pop3: Server did not respond with +OK")
+	if err := GetErr(line); err != nil {
+		return nil, err
 	}
 	return
 }
@@ -102,8 +101,8 @@ func (c *Client) Cmd(format string,
 	if err != nil {
 		return
 	}
-	if !IsOK(line) {
-		return "", errors.New("pop3: Server did not respond with +OK")
+	if err := GetErr(line); err != nil {
+		return "", err
 	}
 	return
 }

--- a/pop3.go
+++ b/pop3.go
@@ -184,12 +184,14 @@ func (c *Client) List(msg int) (list MessageList, err error) {
 		return
 	}
 
-	id, err := strconv.Atoi(strings.Fields(line)[0])
+	f := strings.Fields(line)
+
+	id, err := strconv.Atoi(f[1])
 	if err != nil {
 		return
 	}
 
-	size, err := strconv.Atoi(strings.Fields(line)[1])
+	size, err := strconv.Atoi(f[2])
 	if err != nil {
 		return
 	}

--- a/util.go
+++ b/util.go
@@ -1,6 +1,9 @@
 package pop3
 
-import "strings"
+import (
+	"errors"
+	"strings"
+)
 
 // IsOK checks to see if the reply from the server contains +OK.
 func IsOK(s string) bool {
@@ -16,4 +19,15 @@ func IsErr(s string) bool {
 		return false
 	}
 	return true
+}
+
+// GetErr checks the reply from the server and returns an error
+// if it's not an OK response.
+func GetErr(s string) error {
+	f := strings.Fields(s)
+	if f[0] != ERR {
+		return nil
+	}
+
+	return errors.New(strings.Join(f[1:], " "))
 }


### PR DESCRIPTION
This commit adds a new `GetErr()` method that takes the server response
and returns actual error message from the server in case of an `ERR`
response. The `IsOk()` checks in the client initiation and`Cmd()`
are replaced with this new method to get actual error messages.

There are no breaking changes.